### PR TITLE
fix: remove hardcoded absolute path to playwright-core (privacy/portability)

### DIFF
--- a/scripts/screenshot.mjs
+++ b/scripts/screenshot.mjs
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+﻿#!/usr/bin/env node
 /**
  * Darwin Skill - 高清截图脚本
  *
@@ -15,7 +15,7 @@ import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
 
 // 使用全局安装的 playwright-core
-const pw = require('/Users/alchain/.npm-global/lib/node_modules/playwright/node_modules/playwright-core');
+const pw = require('playwright-core');
 
 const htmlPath = process.argv[2] || new URL('../templates/result-card.html', import.meta.url).pathname;
 const outputPath = process.argv[3] || new URL('../templates/result-card.png', import.meta.url).pathname;

--- a/scripts/screenshot.mjs
+++ b/scripts/screenshot.mjs
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env node
+#!/usr/bin/env node
 /**
  * Darwin Skill - 高清截图脚本
  *
@@ -14,8 +14,18 @@
 import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
 
-// 使用全局安装的 playwright-core
-const pw = require('playwright-core');
+let _pw;
+try {
+  _pw = require('playwright-core');
+} catch {
+  try {
+    _pw = require('playwright');
+  } catch {
+    console.error('Missing Playwright. Please install playwright or playwright-core.');
+    process.exit(1);
+  }
+}
+const pw = _pw;
 
 const htmlPath = process.argv[2] || new URL('../templates/result-card.html', import.meta.url).pathname;
 const outputPath = process.argv[3] || new URL('../templates/result-card.png', import.meta.url).pathname;


### PR DESCRIPTION
﻿Replaces the hardcoded absolute path \/Users/alchain/.npm-global/lib/node_modules/playwright/node_modules/playwright-core\ with a fallback resolution chain. This fixes two issues (closes #4):

1. **Privacy**: the author's home directory path is no longer exposed in source
2. **Portability**: the script now resolves \playwright-core\ or \playwright\ through standard Node.js module resolution instead of using a maintainer-specific absolute path.

### Resolution logic

1. Try \equire('playwright-core')\
2. If that fails, try \equire('playwright')\
3. If both fail, print a clear error and exit

### Testing

- Not run; dependency resolution change only.
